### PR TITLE
Added all runs to the Run Collection API. 

### DIFF
--- a/pops/serializers.py
+++ b/pops/serializers.py
@@ -205,7 +205,7 @@ class SessionSerializer(serializers.ModelSerializer):
 class RunSerializer(serializers.ModelSerializer):
     class Meta:
         model = Run
-        fields = '__all__'
+        exclude = ['management_polygons']
 
 class RunCollectionSerializer(serializers.ModelSerializer):
     class Meta:
@@ -260,6 +260,7 @@ class RunCollectionDetailSerializer(serializers.ModelSerializer):
         model = RunCollection
         fields = '__all__'
 
+    run_set=RunSerializer(many=True)
     second_most_recent_run = serializers.SerializerMethodField()
 
     def get_second_most_recent_run(self, obj):


### PR DESCRIPTION
Added all runs to the Run Collection API. Excluding management polygons for speed. If management polygons are desired in this API, they can be added easily or a separate API can be created to accommodate this situation.