### PR TITLE
Split APIs into detail and write versions to avoid backend writing errors

### DIFF
--- a/pops/serializers.py
+++ b/pops/serializers.py
@@ -256,6 +256,33 @@ class SessionDetailSerializer(serializers.ModelSerializer):
             else:
                 return 'null'
 
+class SessionModelWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Session
+        fields = '__all__'
+
+    runcollection_count = serializers.SerializerMethodField()
+    most_recent_runcollection = serializers.SerializerMethodField()
+    #second_most_recent_runcollection = serializers.SerializerMethodField()
+
+    def get_runcollection_count(self, obj):
+        return obj.runcollection_set.count()
+
+    def get_most_recent_runcollection(self, obj):
+        if obj.runcollection_set.exists():
+            return obj.runcollection_set.order_by('-pk')[0].pk
+        else:
+            return 'null'
+
+    def get_second_most_recent_runcollection(self, obj):
+            if obj.runcollection_set.exists():
+                if obj.runcollection_set.count() > 1:
+                    return obj.runcollection_set.order_by('-pk')[1].pk
+                else: 
+                    return obj.runcollection_set.order_by('-pk')[0].pk
+            else:
+                return 'null'
+
 class RunCollectionDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = RunCollection
@@ -273,6 +300,21 @@ class RunCollectionDetailSerializer(serializers.ModelSerializer):
         else:
             return 'null'
 
+class RunCollectionModelWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RunCollection
+        fields = '__all__'
+
+    second_most_recent_run = serializers.SerializerMethodField()
+
+    def get_second_most_recent_run(self, obj):
+        if obj.run_set.exists():
+            if obj.run_set.count() > 1:
+                return obj.run_set.order_by('-pk')[1].pk
+            else: 
+                return obj.run_set.order_by('-pk')[0].pk
+        else:
+            return 'null'
 
 class OutputPKSerializer(serializers.ModelSerializer):
 
@@ -287,6 +329,19 @@ class RunDetailSerializer(serializers.ModelSerializer):
 
     output_initial_year = serializers.SerializerMethodField()
     output_set=OutputPKSerializer(many=True)
+            
+    def get_output_initial_year(self, obj):
+        if obj.output_set.exists():
+            return obj.output_set.order_by('pk')[0].pk
+        else:
+            return 'null'
+            
+class RunModelWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Run
+        fields = '__all__'
+
+    output_initial_year = serializers.SerializerMethodField()
             
     def get_output_initial_year(self, obj):
         if obj.output_set.exists():

--- a/pops/urls.py
+++ b/pops/urls.py
@@ -8,14 +8,17 @@ from . import views
 router = routers.DefaultRouter()
 router.register('case_study', views.CaseStudyViewSet)
 #router.register('run', views.RunViewSet)
-router.register('run', views.RunDetailViewSet)
-router.register('run_collection', views.RunCollectionDetailViewSet)
+router.register('run', views.RunModelWriteViewSet)
+router.register('run_collection', views.RunCollectionModelWriteViewSet)
+router.register('run_detail', views.RunDetailViewSet)
+router.register('run_collection_detail', views.RunCollectionDetailViewSet)
 #router.register('run_collection', views.RunCollectionViewSet)
 router.register('output', views.OutputViewSet)
 router.register('temperature_data', views.TemperatureDataViewSet)
 router.register('lethal_temperature_data', views.LethalTemperatureDataViewSet)
 router.register('precipitation_data', views.PrecipitationDataViewSet)
-router.register('session', views.SessionDetailViewSet)
+router.register('session', views.SessionModelWriteViewSet)
+router.register('session_detail', views.SessionDetailViewSet)
 
 
 urlpatterns = [

--- a/pops/views/api_views.py
+++ b/pops/views/api_views.py
@@ -47,6 +47,14 @@ class RunCollectionDetailViewSet(viewsets.ModelViewSet):
     serializer_class = RunCollectionDetailSerializer
     permission_classes = (permissions.AllowAny,)
 
+class RunCollectionModelWriteViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows run collections to be viewed or edited.
+    """
+    queryset = RunCollection.objects.all()
+    serializer_class = RunCollectionModelWriteSerializer
+    permission_classes = (permissions.AllowAny,)
+
 class OutputViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows output to be viewed or edited.
@@ -88,10 +96,24 @@ class SessionViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.AllowAny,)
 
 
+class SessionModelWriteViewSet(viewsets.ModelViewSet):
+
+    queryset = Session.objects.all()
+    serializer_class = SessionModelWriteSerializer
+    permission_classes = (permissions.AllowAny,)
+
 class SessionDetailViewSet(viewsets.ModelViewSet):
 
     queryset = Session.objects.prefetch_related('runcollection_set').all()
     serializer_class = SessionDetailSerializer
+    permission_classes = (permissions.AllowAny,)
+
+class RunModelWriteViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows runs to be viewed or edited.
+    """
+    queryset = Run.objects.all()
+    serializer_class = RunModelWriteSerializer
     permission_classes = (permissions.AllowAny,)
 
 class RunDetailViewSet(viewsets.ModelViewSet):
@@ -101,3 +123,4 @@ class RunDetailViewSet(viewsets.ModelViewSet):
     queryset = Run.objects.prefetch_related("output_set").all()
     serializer_class = RunDetailSerializer
     permission_classes = (permissions.AllowAny,)
+


### PR DESCRIPTION
The detailed APIs were causing write errors for the PoPS backend. Created separate "write" and "detail" versions for the problem APIs. 

**Session APIs**
- /api/session/#  _: To be used by the backend PoPS model to write to the database._
- /api/session_detail/#   _: To be used to view detailed information about the database including the run collections associated with the session._

**Run Collection APIs**
- /api/run_collection/#  _: To be used by the backend PoPS model to write to the database._
- /api/run_collection_detail/#  _: To be used to view detailed information about the database including the runs associated with the run collection._

**Run APIs**
- /api/run/#  _: To be used by the backend PoPS model to write to the database._
- /api/run_detail/#  _: To be used to view detailed information about the database including the outputs associated with the run._
