### PR TITLE
Removed django six from tokens

### DIFF
--- a/users/tokens.py
+++ b/users/tokens.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
-from django.utils import six
+#from django.utils import six
 
 class AccountActivationTokenGenerator(PasswordResetTokenGenerator):
     def _make_hash_value(self, user, timestamp):


### PR DESCRIPTION
Django six was removed from the latest django package, causing security token failure in users. I just commented out the line related to django six. This will allow the website to run, but creates a new issue that we need to make a new security token method (we can address this in issue #26). Fixes issue #25 