### PR TITLE
r_data can be null also in Run class in models.py

### DIFF
--- a/pops/models.py
+++ b/pops/models.py
@@ -2207,6 +2207,7 @@ class Run(models.Model):
         upload_to=run_r_data_directory,
         max_length=100,
         blank=True,
+        null=True,
     )
 
     class Meta:


### PR DESCRIPTION
Needed for Tangible Landscape connection, e85353dd82458 added it only to CaseStudy.
(The newline was added automatically in github editor.)